### PR TITLE
React security vulnerability updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@sbddesign/bui-tokens": "^0.0.4",
     "@sbddesign/bui-ui": "^0.0.7",
     "astro": "^5.6.1",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "sharp": "^0.34.2",
     "starlight-llms-txt": "^0.6.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,16 @@ importers:
         version: 0.0.4
       '@sbddesign/bui-ui':
         specifier: ^0.0.7
-        version: 0.0.7(@liquid-js/qrcode-generator@1.1.1)(@types/react@19.1.13)(@xmldom/xmldom@0.9.8)(file-type@19.6.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sharp@0.34.3)
+        version: 0.0.7(@liquid-js/qrcode-generator@1.1.1)(@types/react@19.1.13)(@xmldom/xmldom@0.9.8)(file-type@19.6.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sharp@0.34.3)
       astro:
         specifier: ^5.6.1
         version: 5.13.7(@types/node@24.3.1)(rollup@4.50.1)(typescript@5.9.2)
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       sharp:
         specifier: ^0.34.2
         version: 0.34.3
@@ -1500,13 +1506,13 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
-  react-dom@19.1.1:
-    resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
+  react-dom@19.2.3:
+    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
-      react: ^19.1.1
+      react: ^19.2.3
 
-  react@19.1.1:
-    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
+  react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
   readdirp@4.1.2:
@@ -1608,8 +1614,8 @@ packages:
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
-  scheduler@0.26.0:
-    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -2459,15 +2465,15 @@ snapshots:
     dependencies:
       culori: 4.0.2
 
-  '@sbddesign/bui-ui@0.0.7(@liquid-js/qrcode-generator@1.1.1)(@types/react@19.1.13)(@xmldom/xmldom@0.9.8)(file-type@19.6.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sharp@0.34.3)':
+  '@sbddesign/bui-ui@0.0.7(@liquid-js/qrcode-generator@1.1.1)(@types/react@19.1.13)(@xmldom/xmldom@0.9.8)(file-type@19.6.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sharp@0.34.3)':
     dependencies:
       '@liquid-js/qr-code-styling': 4.0.8(@liquid-js/qrcode-generator@1.1.1)(@xmldom/xmldom@0.9.8)(file-type@19.6.0)(sharp@0.34.3)
       '@lit/react': 1.0.8(@types/react@19.1.13)
       '@sbddesign/bui-icons': 0.0.4
       '@sbddesign/bui-tokens': 0.0.4
       lit: 3.3.1
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - '@liquid-js/qrcode-generator'
       - '@types/react'
@@ -3916,12 +3922,12 @@ snapshots:
 
   radix3@1.1.2: {}
 
-  react-dom@19.1.1(react@19.1.1):
+  react-dom@19.2.3(react@19.2.3):
     dependencies:
-      react: 19.1.1
-      scheduler: 0.26.0
+      react: 19.2.3
+      scheduler: 0.27.0
 
-  react@19.1.1: {}
+  react@19.2.3: {}
 
   readdirp@4.1.2: {}
 
@@ -4132,7 +4138,7 @@ snapshots:
 
   sax@1.4.1: {}
 
-  scheduler@0.26.0: {}
+  scheduler@0.27.0: {}
 
   semver@7.7.2: {}
 


### PR DESCRIPTION
Update React and react-dom to version 19.2.3 to fix React2Shell, Source Code Exposure (CVE-2025-55183), and DoS (CVE-2025-55184) vulnerabilities.

The previous React version (19.1.1) was pulled in transitively via `@sbddesign/bui-ui` and was vulnerable. Adding `react` and `react-dom` as direct dependencies ensures the project uses the patched versions (19.2.3) and is protected against these CVEs. The site builds successfully with the updated dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-249ee593-d5c5-46cc-b870-258c6d16bdbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-249ee593-d5c5-46cc-b870-258c6d16bdbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

